### PR TITLE
Update Dockerfile to use `debugpy` for remote debugging.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ ARG ODOO_VERSION=16.0
 FROM odoo:${ODOO_VERSION}
 EXPOSE 8888
 USER root
-RUN pip3 install ptvsd
-RUN echo "import ptvsd;ptvsd.enable_attach(address=('0.0.0.0', 8888));ptvsd.wait_for_attach()" >> /usr/lib/python3/dist-packages/odoo/addons/__init__.py
+RUN pip3 install debugpy
+RUN echo "import debugpy;debugpy.listen(('0.0.0.0', 8888));debugpy.wait_for_client()" >> /usr/lib/python3/dist-packages/odoo/addons/__init__.py
 USER odoo


### PR DESCRIPTION
Switching over from `ptvsd` to `debugpy`

See following link: https://code.visualstudio.com/docs/python/debugging#_debugging-by-attaching-over-a-network-connection

Microsoft suggest: https://github.com/microsoft/debugpy/wiki/Switching-over-from-%60ptvsd%60-to-%60debugpy%60
Deprecated: https://github.com/microsoft/ptvsd

- Replace `ptvsd` with `debugpy` for remote debugging.
- Change `enable_attach` to `listen` and `wait_for_attach` to `wait_for_client`.
- Update the import statement in `/usr/lib/python3/dist-packages/odoo/addons/__init__.py`.